### PR TITLE
Merge <ctime> fix from upstream

### DIFF
--- a/src/casynth/casynth_ui_main.cxx
+++ b/src/casynth/casynth_ui_main.cxx
@@ -7,6 +7,7 @@
 
 #include "casynth_ui.h"
 #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"
+#include <ctime>
 
 #define CASYNTHUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#casynth_ui"
 

--- a/src/lushlife/lushlife_ui_main.cxx
+++ b/src/lushlife/lushlife_ui_main.cxx
@@ -7,6 +7,7 @@
 
 #include "lushlife_ui.h"
 #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"
+#include <ctime>
 
 #define LUSHLIFEUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#lushlife_ui"
 


### PR DESCRIPTION
Lushlife and CASynth UI files omitted `<ctime>`, which is not allowed since Glibc 2.36.